### PR TITLE
Add sort order and main image flags

### DIFF
--- a/app/Modules/Admin/Product/Models/Images.php
+++ b/app/Modules/Admin/Product/Models/Images.php
@@ -13,7 +13,13 @@ class Images  extends Model
 
     protected $fillable = [
         'title',
-        'path'
+        'path',
+        'sort_order',
+        'is_main'
+    ];
+
+    protected $casts = [
+        'is_main' => 'boolean'
     ];
 
     public function product(): BelongsTo


### PR DESCRIPTION
## Summary
- allow mass assignment of `sort_order` and `is_main` on product images
- cast `is_main` to boolean in Images model

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac918877e48331b1ca5048dbf7e7dd