### PR TITLE
Handle image sort order and main flag

### DIFF
--- a/app/Modules/Admin/Product/Services/ProductService.php
+++ b/app/Modules/Admin/Product/Services/ProductService.php
@@ -35,18 +35,24 @@ class ProductService
         $images = $request->images;
         if (!empty($images) && $images !== 'null') {
             foreach (json_decode($images) as $image) {
+                $sortOrder = (int) ($image->sort_order ?? 0);
+                $isMain = filter_var($image->is_main ?? false, FILTER_VALIDATE_BOOLEAN);
+
                 $imageModel = Images::where(['title' => $image->name])->first();
                 if (empty($imageModel)) {
                     $imageModel = new Images();
                     $imageModel->title = $image->name;
-                    $imageModel->path = '/images/products/' . $model->id. '/'. $image->name;
-                    $imageModel->product_id = $model->id;
-                    $imageModel->save();
-                } else {
-                    $imageModel->path = '/images/products/' . $model->id. '/'. $image->name;
-                    $imageModel->product_id = $model->id;
-                    $imageModel->save();
                 }
+
+                if ($isMain) {
+                    Images::where('product_id', $model->id)->update(['is_main' => false]);
+                }
+
+                $imageModel->path = '/images/products/' . $model->id . '/' . $image->name;
+                $imageModel->product_id = $model->id;
+                $imageModel->sort_order = $sortOrder;
+                $imageModel->is_main = $isMain;
+                $imageModel->save();
             }
         }
         $comments = $request->comments;


### PR DESCRIPTION
## Summary
- parse sort order and main flag for product images
- ensure only one image remains main per product

## Testing
- ⚠️ `composer install --no-interaction --prefer-dist --ignore-platform-req=ext-sodium` (failed: 403 cloning from GitHub)
- ⚠️ `phpunit` (command not found after failed install)


------
https://chatgpt.com/codex/tasks/task_e_68ac9331d8b483318aa1ff01863cca13