### PR TITLE
feat: enable sorting and main image selection

### DIFF
--- a/app/Modules/Admin/Product/Controllers/ProductController.php
+++ b/app/Modules/Admin/Product/Controllers/ProductController.php
@@ -136,28 +136,26 @@ class ProductController extends Base
      */
     public function images(Request $request)
     {
-//        dd($request->all());
         $input = [];
-        if ($images = $request->file('images')) {
+        if ($image = $request->file('images')) {
             $destinationPath = 'images/products';
-            foreach ($images as $image) {
-                //$profileImage = date('YmdHis') . "." . $image->getClientOriginalExtension();
-                $profileImage = $image->getClientOriginalName();
-                $imageModel = Images::where(['title' => $profileImage])->first();
-                if (empty($imageModel)) {
-                    $image->move($destinationPath, $profileImage);
-                    $imageModel = new Images();
-                    $imageModel->title = $profileImage;
-                    $imageModel->path = '/images/products/' . $profileImage;
-                    $imageModel->save();
-                }
-                $input[] = [
-                    'path' => '/images/products/' . $profileImage,
-                    'name' => $profileImage
-                ];
+            $profileImage = $image->getClientOriginalName();
+            $imageModel = Images::where(['title' => $profileImage])->first();
+            if (empty($imageModel)) {
+                $image->move($destinationPath, $profileImage);
+                $imageModel = new Images();
+                $imageModel->title = $profileImage;
+                $imageModel->path = '/images/products/' . $profileImage;
+                $imageModel->save();
             }
+            $input = [
+                'path' => '/images/products/' . $profileImage,
+                'name' => $profileImage,
+                'sort_order' => 0,
+                'is_main' => false
+            ];
         }
-        return json_encode($input);
+        return response()->json($input);
     }
 
     /**
@@ -177,7 +175,9 @@ class ProductController extends Base
             foreach ($product->images as $image) {
                 $images[] = [
                     'path' => $image->path,
-                    'name' => $image->title
+                    'name' => $image->title,
+                    'sort_order' => $image->sort_order,
+                    'is_main' => $image->is_main,
                 ];
             }
         }

--- a/resources/views/Admin/Product/edit.blade.php
+++ b/resources/views/Admin/Product/edit.blade.php
@@ -203,7 +203,11 @@
                                             @if($images)
                                                 @foreach($images as $image)
                                                     <div id=""
-                                                         class="row mt-2 dz-processing dz-image-preview dz-complete">
+                                                         class="row mt-2 dz-processing dz-image-preview dz-complete"
+                                                         data-path="{{$image['path']}}"
+                                                         data-name="{{$image['name']}}"
+                                                         data-sort-order="{{$image['sort_order']}}"
+                                                         data-is-main="{{$image['is_main'] ? 1 : 0}}">
                                                         <div class="col-auto">
                                             <span class="preview">
                                                 <img width="80" height="80"


### PR DESCRIPTION
## Summary
- add sort order and main image flags to product image uploads and edit view
- enable drag-and-drop sorting with main image radio controls
- return sort and main metadata from image upload endpoint

## Testing
- `composer install --no-progress --no-interaction` *(fails: ext-sodium missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ac8db293bc8331abcd762f453e44e8