### PR TITLE
Add image index and main selection controls

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,6 +1,14 @@
 .hidden{
     display: none;
 }
+.dz-preview .image-index {
+    min-width: 24px;
+    text-align: center;
+}
+
+.dz-preview .is-main {
+    margin-top: 5px;
+}
 .content .save {
     margin: 15px;
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,12 @@
 .hidden{
     display: none;
 }
+
+.dz-preview .image-index {
+    min-width: 24px;
+    text-align: center;
+}
+
+.dz-preview .is-main {
+    margin-top: 5px;
+}

--- a/resources/views/Admin/Product/edit.blade.php
+++ b/resources/views/Admin/Product/edit.blade.php
@@ -208,6 +208,10 @@
                                                          data-name="{{$image['name']}}"
                                                          data-sort-order="{{$image['sort_order']}}"
                                                          data-is-main="{{$image['is_main'] ? 1 : 0}}">
+                                                        <div class="col-auto d-flex flex-column align-items-center justify-content-center">
+                                                            <span class="badge badge-info image-index">{{$loop->iteration}}</span>
+                                                            <input type="radio" class="is-main mt-1" name="main_image">
+                                                        </div>
                                                         <div class="col-auto">
                                             <span class="preview">
                                                 <img width="80" height="80"
@@ -257,6 +261,10 @@
 
 
                                             <div id="template" class="row mt-2">
+                                                <div class="col-auto d-flex flex-column align-items-center justify-content-center">
+                                                    <span class="badge badge-info image-index"></span>
+                                                    <input type="radio" class="is-main mt-1" name="main_image">
+                                                </div>
                                                 <div class="col-auto">
                                             <span class="preview">
                                                   <img src="data:," alt="" data-dz-thumbnail/>

--- a/resources/views/Admin/layouts/parts/footer.blade.php
+++ b/resources/views/Admin/layouts/parts/footer.blade.php
@@ -322,7 +322,6 @@
             }
             file.previewElement.dataset.path = data.path;
             file.previewElement.dataset.name = data.name;
-            $(file.previewElement).append('<input type="radio" class="is-main" name="main_image">');
             refreshImagesField();
         },
         error: function (file, response) {
@@ -365,6 +364,7 @@
     function refreshImagesField() {
         var images = [];
         $('#previews .dz-preview').each(function (index) {
+            $(this).find('.image-index').text(index + 1);
             images.push({
                 name: $(this).data('name'),
                 path: $(this).data('path'),
@@ -389,12 +389,9 @@
         refreshImagesField();
     });
 
-    $('#previews .dz-preview').each(function () {
-        if ($(this).data('is-main') == 1) {
-            $(this).append('<input type="radio" class="is-main" name="main_image" checked>');
-        } else {
-            $(this).append('<input type="radio" class="is-main" name="main_image">');
-        }
+    $('#previews .dz-preview').each(function (index) {
+        $(this).find('.image-index').text(index + 1);
+        $(this).find('.is-main').prop('checked', $(this).data('is-main') == 1);
     });
     refreshImagesField();
 


### PR DESCRIPTION
## Summary
- show image order badges and a main-image radio button for each preview
- update JS to keep indices in sync and serialize selected main image
- style new image controls in admin CSS

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-sodium` *(fails: repeated 403 downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68aca90bda3883318d4a767087ab9d84