### PR TITLE
Limit Dropzone area and refresh sortable previews

### DIFF
--- a/resources/views/Admin/layouts/parts/footer.blade.php
+++ b/resources/views/Admin/layouts/parts/footer.blade.php
@@ -293,7 +293,7 @@
     var previewTemplate = previewNode.parentNode.innerHTML
     previewNode.parentNode.removeChild(previewNode)
 
-    var myDropzone = new Dropzone(document.body, { // Make the whole body a dropzone
+    var myDropzone = new Dropzone('#actions', {
         url: "/admin/products/images", // Set the url
         headers: {
             'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
@@ -375,6 +375,9 @@
         document.querySelector('#images').value = JSON.stringify(images);
     }
 
+    if ($('#previews').data('ui-sortable')) {
+        $('#previews').sortable('destroy');
+    }
     $('#previews').sortable({
         items: '.dz-preview',
         update: refreshImagesField


### PR DESCRIPTION
## Summary
- Attach Dropzone to `#actions` so uploads don't hijack whole page
- Reinitialize preview sortable list to keep image order in sync

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68acb39304f0833180e9021bd81cd48c