### PR TITLE
Fix product image payload handling

### DIFF
--- a/app/Modules/Admin/Product/Services/ProductService.php
+++ b/app/Modules/Admin/Product/Services/ProductService.php
@@ -33,9 +33,10 @@ class ProductService
         $new = $request->new;
         $new === 'on' ? $model->new = 1 : $model->new = 0;
         $model->save();
-        $images = $request->images;
+        $images = $request->input('image_payload');
         if (!empty($images) && $images !== 'null') {
-            foreach (json_decode($images) as $image) {
+            $images = is_string($images) ? json_decode($images) : $images;
+            foreach ($images as $image) {
                 $sortOrder = (int) ($image->sort_order ?? 0);
                 $isMain = filter_var($image->is_main ?? false, FILTER_VALIDATE_BOOLEAN);
 

--- a/resources/views/Admin/Product/edit.blade.php
+++ b/resources/views/Admin/Product/edit.blade.php
@@ -168,7 +168,7 @@
                                 <fieldset class="mb-3">
                                     <div class="card-body">
                                         <input type="file" id="product-images" multiple>
-                                        <input id="images" name="images" type="hidden" value="{{ json_encode($images) ?? '' }}"/>
+                                        <input id="image_payload" name="image_payload" type="hidden" value="{{ json_encode($images) ?? '' }}"/>
                                         <div id="image-list" class="mt-3"></div>
                                     </div>
                                 </fieldset>

--- a/resources/views/Admin/layouts/parts/footer.blade.php
+++ b/resources/views/Admin/layouts/parts/footer.blade.php
@@ -372,7 +372,7 @@
                 is_main: $(this).find('.is-main').is(':checked')
             });
         });
-        document.querySelector('#images').value = JSON.stringify(images);
+        document.querySelector('#image_payload').value = JSON.stringify(images);
     }
 
     if ($('#previews').data('ui-sortable')) {
@@ -443,7 +443,7 @@ tinymce.init({
     document.addEventListener('DOMContentLoaded', () => {
         const fileInput = document.getElementById('product-images');
         const imageList = document.getElementById('image-list');
-        const imagesInput = document.getElementById('images');
+        const imagesInput = document.getElementById('image_payload');
         if (!fileInput || !imageList || !imagesInput) return;
 
         const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content');


### PR DESCRIPTION
## Summary
- rename product edit hidden field to `image_payload`
- reference `image_payload` in footer scripts
- accept array or JSON image payloads in ProductService

## Testing
- `vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68acbce201f88331aee5dfdc88c1dacb