### PR TITLE
Preserve main image selection

### DIFF
--- a/app/Modules/Admin/Product/Services/ProductService.php
+++ b/app/Modules/Admin/Product/Services/ProductService.php
@@ -36,9 +36,21 @@ class ProductService
         $images = $request->input('image_payload');
         if (!empty($images) && $images !== 'null') {
             $images = is_string($images) ? json_decode($images) : $images;
-            foreach ($images as $image) {
+
+            $hasMain = false;
+            foreach ($images as $img) {
+                if (filter_var($img->is_main ?? false, FILTER_VALIDATE_BOOLEAN)) {
+                    $hasMain = true;
+                    break;
+                }
+            }
+
+            foreach ($images as $index => $image) {
                 $sortOrder = (int) ($image->sort_order ?? 0);
                 $isMain = filter_var($image->is_main ?? false, FILTER_VALIDATE_BOOLEAN);
+                if (!$hasMain && $index === 0) {
+                    $isMain = true;
+                }
 
                 $imageModel = Images::where(['title' => $image->name])->first();
                 if (empty($imageModel)) {

--- a/resources/views/Admin/Product/edit.blade.php
+++ b/resources/views/Admin/Product/edit.blade.php
@@ -169,7 +169,18 @@
                                     <div class="card-body">
                                         <input type="file" id="product-images" multiple>
                                         <input id="image_payload" name="image_payload" type="hidden" value="{{ json_encode($images) ?? '' }}"/>
-                                        <div id="image-list" class="mt-3"></div>
+                                        <div id="image-list" class="mt-3">
+                                            @if(!empty($images))
+                                                @foreach($images as $image)
+                                                    <div class="image-item d-flex align-items-center mb-2" data-name="{{ $image['name'] }}" data-path="{{ $image['path'] }}">
+                                                        <img src="{{ $image['path'] }}" width="80" height="80" class="mr-2">
+                                                        <input type="number" class="form-control sort-order mr-2" name="images[{{ $loop->index }}][sort_order]" value="{{ $image['sort_order'] ?? 0 }}">
+                                                        <input type="radio" name="main_image" class="mr-2" {{ $image['is_main'] ? 'checked' : '' }}>
+                                                        <button type="button" class="btn btn-danger btn-sm delete-image">Delete</button>
+                                                    </div>
+                                                @endforeach
+                                            @endif
+                                        </div>
                                     </div>
                                 </fieldset>
                             </div>

--- a/resources/views/Admin/layouts/parts/footer.blade.php
+++ b/resources/views/Admin/layouts/parts/footer.blade.php
@@ -362,14 +362,27 @@
     }
 
     function refreshImagesField() {
+        var previous = [];
+        var currentVal = document.querySelector('#image_payload').value;
+        if (currentVal) {
+            try {
+                previous = JSON.parse(currentVal);
+            } catch (e) {
+                previous = [];
+            }
+        }
+
         var images = [];
+        var hasSelected = $('#previews .is-main:checked').length > 0;
         $('#previews .dz-preview').each(function (index) {
             $(this).find('.image-index').text(index + 1);
+            var checked = $(this).find('.is-main').is(':checked');
+            var prevIsMain = previous[index] ? previous[index].is_main : 0;
             images.push({
                 name: $(this).data('name'),
                 path: $(this).data('path'),
                 sort_order: index,
-                is_main: $(this).find('.is-main').is(':checked')
+                is_main: hasSelected ? (checked ? 1 : 0) : (prevIsMain ? 1 : 0)
             });
         });
         document.querySelector('#image_payload').value = JSON.stringify(images);
@@ -471,7 +484,7 @@ tinymce.init({
                 const name = item.dataset.name;
                 const path = item.dataset.path;
                 const sort = item.querySelector('.sort-order').value;
-                const isMain = item.querySelector('input[type="radio"]').checked;
+                const isMain = item.querySelector('input[type="radio"]').checked ? 1 : 0;
                 data.push({name, path, sort_order: Number(sort), is_main: isMain});
             });
             imagesInput.value = JSON.stringify(data);
@@ -565,7 +578,9 @@ tinymce.init({
         });
 
         const existing = imagesInput.value ? JSON.parse(imagesInput.value) : [];
-        existing.forEach(img => createImageItem(img));
+        if (imageList.children.length === 0) {
+            existing.forEach(img => createImageItem(img));
+        }
         updateSortOrderNames();
         updateImagesField();
     });


### PR DESCRIPTION
## Summary
- Render existing images with checked main selection in product edit
- Preserve and reuse main image flags when refreshing image payload
- Default main image only when none provided in service logic

## Testing
- `vendor/bin/phpunit` *(fails: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0255c008331901969c06e1baad3