### PR TITLE
Enable deleting product images from edit view

### DIFF
--- a/app/Modules/Admin/Product/Controllers/ProductController.php
+++ b/app/Modules/Admin/Product/Controllers/ProductController.php
@@ -187,6 +187,7 @@ class ProductController extends Base
         if (isset($product->images)) {
             foreach ($product->images as $image) {
                 $images[] = [
+                    'id' => $image->id,
                     'path' => $image->path,
                     'name' => $image->title,
                     'sort_order' => $image->sort_order,

--- a/app/Modules/Admin/Product/Services/ProductService.php
+++ b/app/Modules/Admin/Product/Services/ProductService.php
@@ -33,6 +33,20 @@ class ProductService
         $new = $request->new;
         $new === 'on' ? $model->new = 1 : $model->new = 0;
         $model->save();
+        $deleted = $request->input('deleted_images', []);
+        if (!empty($deleted)) {
+            foreach ((array)$deleted as $imageId) {
+                $imageModel = Images::find($imageId);
+                if ($imageModel) {
+                    $filePath = public_path(ltrim($imageModel->path, '/'));
+                    if (File::exists($filePath)) {
+                        File::delete($filePath);
+                    }
+                    $imageModel->delete();
+                }
+            }
+        }
+
         $images = $request->input('image_payload');
         if (!empty($images) && $images !== 'null') {
             $images = is_string($images) ? json_decode($images) : $images;

--- a/app/Modules/Pub/Categories/Controllers/CategoriesController.php
+++ b/app/Modules/Pub/Categories/Controllers/CategoriesController.php
@@ -43,15 +43,15 @@ class CategoriesController extends Base
         $all = $request->all();
 //        dd($all);
         $ids = $category->products->pluck('id')->toArray();
+        $query = Product::with(['mainImage', 'images'])->whereIn('id', $ids);
         if (isset($all['priceFrom']) && isset($all['priceTo'])){
             $priceFrom = $all['priceFrom'];
             $priceTo = $all['priceTo'];
             if ($priceFrom !== '0' || $priceTo !== '1000000') {
-                $products = Product::whereIn('id', $ids)->whereBetween('price', [$all['priceFrom'], $all['priceTo']])->paginate(config('settings.pagination'));
+                $query->whereBetween('price', [$all['priceFrom'], $all['priceTo']]);
             }
-        } else {
-            $products = Product::whereIn('id',$ids)->paginate(config('settings.pagination'));
         }
+        $products = $query->paginate(config('settings.pagination'));
         $this->title = $category->meta_title;
         $this->meta_description = $category->meta_description;
         $this->meta_keys = $category->meta_keys;

--- a/app/Modules/Pub/Home/Controllers/HomeController.php
+++ b/app/Modules/Pub/Home/Controllers/HomeController.php
@@ -38,8 +38,12 @@ class HomeController extends Base
             }
         }
         $categories = Categories::where(['parent_id' => null])->get();
-        $newProducts = Product::where(['new' => 1],['category_product_id'=>1])->whereNotNull('status')->limit(8)->get();
-        $hitProducts = Product::where(['hit' => 1],['category_product_id'=>1])->whereNotNull('status')->limit(8)->get();
+        $newProducts = Product::with(['mainImage', 'images'])
+            ->where(['new' => 1], ['category_product_id' => 1])
+            ->whereNotNull('status')->limit(8)->get();
+        $hitProducts = Product::with(['mainImage', 'images'])
+            ->where(['hit' => 1], ['category_product_id' => 1])
+            ->whereNotNull('status')->limit(8)->get();
         $this->content = view('Pub::Home.index')->with([
             'title' => $page->title,
             'banners' => $banners,

--- a/app/Modules/Pub/Orders/Controllers/OrdersController.php
+++ b/app/Modules/Pub/Orders/Controllers/OrdersController.php
@@ -105,7 +105,8 @@ class OrdersController extends Base
         } else {
             $message = __('front.card.empty');
             foreach ($session['items'] as $item) {
-                $product = Product::find($item['product_id']);
+                $product = Product::with(['mainImage', 'images'])->find($item['product_id']);
+                $image = $product->mainImage->path ?? ($product->images[0]->path ?? null);
                 $products[] = [
                     'id' => $product->id,
                     'title' => $product->title,
@@ -113,7 +114,7 @@ class OrdersController extends Base
                     'price' => $product->price,
                     'product_code' => $product->product_code,
                     'count' => $item['count'],
-                    'image' => $product->images[0]->path,
+                    'image' => $image,
                     'countPrice' => round($item['count'] * $product->price)
                 ];
                 $price += round($item['count'] * $product->price);

--- a/app/Modules/Pub/Products/Controllers/ProductsController.php
+++ b/app/Modules/Pub/Products/Controllers/ProductsController.php
@@ -17,16 +17,22 @@ class ProductsController extends Base
      */
     public function show(Product $product)
     {
+        $product->load(['images', 'mainImage', 'categoryProduct']);
+        $related = $product->categoryProduct->products()
+            ->with(['mainImage', 'images'])
+            ->get()
+            ->filter(function ($item) {
+                if ((int)$item->price !== 0) {
+                    return $item;
+                }
+            })->forPage(0, 6);
+
         $this->title = $product->title;
         $this->content = view('Pub::Products.show')->with([
             'title' => $this->title,
             'product' => $product,
             'comments' => $product->comments,
-            'products' => $product->categoryProduct->products->filter(function ($item, $key) {
-                if ((int)$item->price !== 0) {
-                    return $item;
-                }
-            })->forPage(0, 6),
+            'products' => $related,
             'phone' => config('settings.phone'),
             'delivery' => config('settings.delivery')
         ])->render();

--- a/resources/views/Admin/Product/edit.blade.php
+++ b/resources/views/Admin/Product/edit.blade.php
@@ -176,7 +176,7 @@
                                                         <img src="{{ $image['path'] }}" width="80" height="80" class="mr-2">
                                                         <input type="number" class="form-control sort-order mr-2" name="images[{{ $loop->index }}][sort_order]" value="{{ $image['sort_order'] ?? 0 }}">
                                                         <input type="radio" name="main_image" class="mr-2" {{ $image['is_main'] ? 'checked' : '' }}>
-                                                        <button type="button" class="btn btn-danger btn-sm delete-image">Delete</button>
+                                                        <button type="button" class="btn btn-danger btn-sm image-delete" data-id="{{ $image['id'] }}">×</button>
                                                     </div>
                                                 @endforeach
                                             @endif

--- a/resources/views/Pub/Categories/show.blade.php
+++ b/resources/views/Pub/Categories/show.blade.php
@@ -126,17 +126,18 @@
                                                              src="{{asset('images/hot-deal.png')}}"
                                                              alt="{{$product->title}}">
                                                     @endif
+                                                    @php($image = $product->mainImage->path ?? ($product->images[0]->path ?? ''))
                                                     <picture class="product-list-item__content__img">
                                                         <source type="image/webp" media="(max-width: 500px)"
-                                                                data-srcset="{{$product->images[0]->path}}"
-                                                                srcset="{{$product->images[0]->path}}">
+                                                                data-srcset="{{$image}}"
+                                                                srcset="{{$image}}">
                                                         <source itemprop="image" type="image/webp"
                                                                 media="(min-width: 992px)"
-                                                                data-srcset="{{$product->images[0]->path}}"
-                                                                srcset="{{$product->images[0]->path}}">
+                                                                data-srcset="{{$image}}"
+                                                                srcset="{{$image}}">
                                                         <img itemprop="image"
-                                                             src="{{$product->images[0]->path}}"
-                                                             data-src="{{$product->images[0]->path}}"
+                                                             src="{{$image}}"
+                                                             data-src="{{$image}}"
                                                              class="img-fluid lazy loaded"
                                                              alt="{{$product->title}}"
                                                              data-was-processed="true">

--- a/resources/views/Pub/Home/index.blade.php
+++ b/resources/views/Pub/Home/index.blade.php
@@ -126,18 +126,14 @@
                                             <meta itemprop="priceCurrency" content="UAH">
                                             <meta itemprop="itemCondition" content="https://schema.org/UsedCondition">
                                             <meta itemprop="price" content="{{$new->price}}">
-                                            <picture class="product-item__img">
-                                                @if (!empty($new->images[0]))
-                                                    <source type="image/webp" media="(max-width:991px)"
-                                                            srcset="{{$new->images[0]->path}}">
-                                                    <source itemprop="image" type="image/webp"
-                                                            media="(min-width: 992px)"
-                                                            srcset="{{$new->images[0]->path}}">
-                                                    <img src="{{$new->images[0]->path}}" width="168" height="155"
-                                                         data-src="{{$new->images[0]->path}}"
-                                                         alt="{{$new->title}}" class="img-fluid lazy">
-                                                @endif
-                                            </picture>
+                                            @php($image = $new->mainImage->path ?? ($new->images[0]->path ?? null))
+                                            @if ($image)
+                                                <picture class="product-item__img">
+                                                    <source type="image/webp" media="(max-width:991px)" srcset="{{$image}}">
+                                                    <source itemprop="image" type="image/webp" media="(min-width: 992px)" srcset="{{$image}}">
+                                                    <img src="{{$image}}" width="168" height="155" data-src="{{$image}}" alt="{{$new->title}}" class="img-fluid lazy">
+                                                </picture>
+                                            @endif
                                             <span class="product-item__label">
                                                 <span class="label-outer"></span>
                                            </span>
@@ -254,18 +250,14 @@
                                             <meta itemprop="priceCurrency" content="UAH">
                                             <meta itemprop="itemCondition" content="https://schema.org/UsedCondition">
                                             <meta itemprop="price" content="{{$hit->price}}">
-                                            <picture class="product-item__img">
-                                                @if (!empty($hit->images[0]))
-                                                    <source type="image/webp" media="(max-width:991px)"
-                                                            srcset="{{$hit->images[0]->path}}">
-                                                    <source itemprop="image" type="image/webp"
-                                                            media="(min-width: 992px)"
-                                                            srcset="{{$hit->images[0]->path}}">
-                                                    <img src="{{$hit->images[0]->path}}" width="168" height="155"
-                                                         data-src="{{$hit->images[0]->path}}"
-                                                         alt="{{$hit->title}}" class="img-fluid lazy">
-                                                @endif
-                                            </picture>
+                                            @php($image = $hit->mainImage->path ?? ($hit->images[0]->path ?? null))
+                                            @if ($image)
+                                                <picture class="product-item__img">
+                                                    <source type="image/webp" media="(max-width:991px)" srcset="{{$image}}">
+                                                    <source itemprop="image" type="image/webp" media="(min-width: 992px)" srcset="{{$image}}">
+                                                    <img src="{{$image}}" width="168" height="155" data-src="{{$image}}" alt="{{$hit->title}}" class="img-fluid lazy">
+                                                </picture>
+                                            @endif
                                             <span class="product-item__label">
                                                 <span class="label-outer"></span>
                                            </span>

--- a/resources/views/Pub/Products/show.blade.php
+++ b/resources/views/Pub/Products/show.blade.php
@@ -320,15 +320,14 @@
                                         <meta itemprop="itemCondition" content="https://schema.org/UsedCondition">
                                         <meta itemprop="price" content="{{$item->price}}">
 
-                                        @if ($item->images)
+                                        @php($image = $item->mainImage->path ?? ($item->images[0]->path ?? null))
+                                        @if ($image)
                                             <picture class="product-item__img">
-                                                <source type="image/webp" media="(max-width:991px)"
-                                                        srcset="{{$item->images[0]->path}}">
-                                                <source itemprop="image" type="image/webp" media="(min-width: 992px)"
-                                                        srcset="{{$item->images[0]->path}}">
-                                                <img src="{{$item->images[0]->path}}" width="168"
+                                                <source type="image/webp" media="(max-width:991px)" srcset="{{$image}}">
+                                                <source itemprop="image" type="image/webp" media="(min-width: 992px)" srcset="{{$image}}">
+                                                <img src="{{$image}}" width="168"
                                                      height="155"
-                                                     data-src="{{$item->images[0]->path}}"
+                                                     data-src="{{$image}}"
                                                      alt="{{$item->title}}"
                                                      class="img-fluid lazy loaded" data-was-processed="true">
                                             </picture>


### PR DESCRIPTION
## Summary
- Add delete buttons to product image previews and track removed IDs
- Refresh image payload on client-side and send `deleted_images[]` to server
- Remove deleted images and files in ProductService
- Load and display main product images on storefront listings and cart

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acc29b57cc833183727dc70b65192b