### PR TITLE
enforce product status availability

### DIFF
--- a/app/Modules/Pub/Categories/Controllers/CategoriesController.php
+++ b/app/Modules/Pub/Categories/Controllers/CategoriesController.php
@@ -43,7 +43,8 @@ class CategoriesController extends Base
         $all = $request->all();
 //        dd($all);
         $ids = $category->products->pluck('id')->toArray();
-        $query = Product::with(['mainImage', 'images'])->whereIn('id', $ids);
+        $query = Product::with(['mainImage', 'images'])->whereIn('id', $ids)
+            ->where('status', '>', 0);
         if (isset($all['priceFrom']) && isset($all['priceTo'])){
             $priceFrom = $all['priceFrom'];
             $priceTo = $all['priceTo'];

--- a/app/Modules/Pub/Home/Controllers/HomeController.php
+++ b/app/Modules/Pub/Home/Controllers/HomeController.php
@@ -40,10 +40,10 @@ class HomeController extends Base
         $categories = Categories::where(['parent_id' => null])->get();
         $newProducts = Product::with(['mainImage', 'images'])
             ->where(['new' => 1], ['category_product_id' => 1])
-            ->whereNotNull('status')->limit(8)->get();
+            ->where('status', '>', 0)->limit(8)->get();
         $hitProducts = Product::with(['mainImage', 'images'])
             ->where(['hit' => 1], ['category_product_id' => 1])
-            ->whereNotNull('status')->limit(8)->get();
+            ->where('status', '>', 0)->limit(8)->get();
         $this->content = view('Pub::Home.index')->with([
             'title' => $page->title,
             'banners' => $banners,

--- a/app/Modules/Pub/Products/Controllers/ProductsController.php
+++ b/app/Modules/Pub/Products/Controllers/ProductsController.php
@@ -17,9 +17,13 @@ class ProductsController extends Base
      */
     public function show(Product $product)
     {
+        if ((int)$product->status === 0) {
+            abort(404);
+        }
         $product->load(['images', 'mainImage', 'categoryProduct']);
         $related = $product->categoryProduct->products()
             ->with(['mainImage', 'images'])
+            ->where('status', '>', 0)
             ->get()
             ->filter(function ($item) {
                 if ((int)$item->price !== 0) {


### PR DESCRIPTION
## Summary
- enforce status > 0 for new and hit home page products
- filter category listings and related products by active status
- abort product view when product is inactive

## Testing
- `./vendor/bin/phpunit` *(fails: InvalidArgumentException: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68ad52761bec83319502b75a5fcea6c2