### PR TITLE
Handle product availability statuses

### DIFF
--- a/resources/views/Pub/Categories/show.blade.php
+++ b/resources/views/Pub/Categories/show.blade.php
@@ -155,11 +155,20 @@
                                                         {{$product->price}}
                                                         <span itemprop="priceCurrency" content="UAH">₴</span></ins>
 
-                                                    <p itemprop="availability" href="https://schema.org/InStock"
-                                                       class="product-list-item__basket__available"> Продукт є в
-                                                        наявності, замовляйте сьогодні!</p>
-                                                    <a href="{{route('order',['product'=>$product->id])}}"
-                                                       class="product-list-item__basket__btn">додати до кошика</a>
+                                                    @if($product->status == 1)
+                                                        <p itemprop="availability" href="https://schema.org/InStock"
+                                                           class="product-list-item__basket__available">Є</p>
+                                                        <a href="{{route('order',['product'=>$product->id])}}"
+                                                           class="product-list-item__basket__btn">додати до кошика</a>
+                                                    @elseif($product->status == 2)
+                                                        <p itemprop="availability" href="https://schema.org/InStock"
+                                                           class="product-list-item__basket__available">Під замовлення</p>
+                                                        <a href="{{route('order',['product'=>$product->id])}}"
+                                                           class="product-list-item__basket__btn">додати до кошика</a>
+                                                    @elseif($product->status == 3)
+                                                        <p itemprop="availability" href="https://schema.org/InStock"
+                                                           class="product-list-item__basket__available">В дорозі</p>
+                                                    @endif
                                                     <a href="{{route('products.show',['product'=>$product->url])}}"
                                                        class="product-list-item__basket__btn product-list-item__basket__btn-more"
                                                        title="Подробиці продукт">Подробиці продукт</a>

--- a/resources/views/Pub/Products/show.blade.php
+++ b/resources/views/Pub/Products/show.blade.php
@@ -187,19 +187,36 @@
                                                             xlink:href="{{asset('images/icons.svg')}}#icon-delivery-truck"></use>
                                                     </svg>Вартість доставки від: <span> {{$delivery}} ₴</span></span>
 
-                                                <p itemprop="availability" href="https://schema.org/InStock"
-                                                   class="product-list-item__basket__available available">
-                                                    Товар в наявності, замовляйте сьогодні!</p>
-                                                <a href="{{route('order',['product'=>$product->id])}}" type="button"
-                                                   class="product-list-item__basket__btn add-cart available"
-                                                   id="add-cart">Додати в кошик</a>
-                                                <button type="button"
-                                                        class="byProduct"
-                                                        data-toggle="modal"
-                                                        data-target="#byProduct"
-                                                        style="padding: 15px 25px;border-radius: 25px;background: #51AD33;color: white;font-weight: bold;">
-                                                    Купити в один клік
-                                                </button>
+                                                @if($product->status == 1)
+                                                    <p itemprop="availability" href="https://schema.org/InStock"
+                                                       class="product-list-item__basket__available available">Є</p>
+                                                    <a href="{{route('order',['product'=>$product->id])}}" type="button"
+                                                       class="product-list-item__basket__btn add-cart available"
+                                                       id="add-cart">Додати в кошик</a>
+                                                    <button type="button"
+                                                            class="byProduct"
+                                                            data-toggle="modal"
+                                                            data-target="#byProduct"
+                                                            style="padding: 15px 25px;border-radius: 25px;background: #51AD33;color: white;font-weight: bold;">
+                                                        Купити в один клік
+                                                    </button>
+                                                @elseif($product->status == 2)
+                                                    <p itemprop="availability" href="https://schema.org/InStock"
+                                                       class="product-list-item__basket__available available">Під замовлення</p>
+                                                    <a href="{{route('order',['product'=>$product->id])}}" type="button"
+                                                       class="product-list-item__basket__btn add-cart available"
+                                                       id="add-cart">Додати в кошик</a>
+                                                    <button type="button"
+                                                            class="byProduct"
+                                                            data-toggle="modal"
+                                                            data-target="#byProduct"
+                                                            style="padding: 15px 25px;border-radius: 25px;background: #51AD33;color: white;font-weight: bold;">
+                                                        Купити в один клік
+                                                    </button>
+                                                @elseif($product->status == 3)
+                                                    <p itemprop="availability" href="https://schema.org/InStock"
+                                                       class="product-list-item__basket__available">В дорозі</p>
+                                                @endif
                                                 <div class="product-list-item__basket__benefits available">
                                                     <span>
                                                         <svg class="icon-return"><use


### PR DESCRIPTION
## Summary
- Display availability and purchase options based on product status in product detail view
- Apply same availability logic to product cards in category listings

## Testing
- `vendor/bin/phpunit` *(fails: InvalidArgumentException: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68ad55f5a18c8331a523f3aa39976fc6